### PR TITLE
CI: adding rendering for local CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,29 @@
+version: 2.1
+
+jobs:
+
+  build-docs:
+    docker:
+      - image: cimg/python:3.11
+
+    steps:
+      - checkout
+
+      - run:
+          name: Install CI dependencies
+          command: python -m pip install --upgrade tox
+
+      - run:
+          name: Build HTML rendering of notebooks
+          no_output_timeout: 30m
+          command: |
+            python -m tox -e py311-buildhtml
+
+      - store_artifacts:
+          path: _build/html
+
+workflows:
+  version: 2
+  default:
+    jobs:
+      - build-docs

--- a/.github/workflows/circleci-artifacts-redirector.yml
+++ b/.github/workflows/circleci-artifacts-redirector.yml
@@ -10,6 +10,6 @@ jobs:
         uses: scientific-python/circleci-artifacts-redirector-action@4e13a10d89177f4bfc8007a7064bdbeda848d8d1  # v1.0.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          api-token: ${{ secrets.FORNAX_NOTEBOOKS_CIRCLE_TOKEN }}
+          api-token: ${{ secrets.FORNAX_DOCUMENTATION_CIRCLE_TOKEN }}
           artifact-path: 0/_build/html/index.html
           circleci-jobs: build-docs

--- a/.github/workflows/circleci-artifacts-redirector.yml
+++ b/.github/workflows/circleci-artifacts-redirector.yml
@@ -1,0 +1,15 @@
+name: Run CircleCI artifacts redirector, rendered pages are under Details
+
+on: [status]
+jobs:
+  circleci_artifacts_redirector_job:
+    runs-on: ubuntu-latest
+    name: Run CircleCI artifacts redirector
+    steps:
+      - name: GitHub Action step
+        uses: scientific-python/circleci-artifacts-redirector-action@4e13a10d89177f4bfc8007a7064bdbeda848d8d1  # v1.0.0
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          api-token: ${{ secrets.FORNAX_NOTEBOOKS_CIRCLE_TOKEN }}
+          artifact-path: 0/_build/html/index.html
+          circleci-jobs: build-docs

--- a/conf.py
+++ b/conf.py
@@ -1,0 +1,67 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# -- Path setup --------------------------------------------------------------
+
+# If extensions (or modules to document with autodoc) are in another directory,
+# add these directories to sys.path here. If the directory is relative to the
+# documentation root, use os.path.abspath to make it absolute, like shown here.
+#
+# import os
+# import sys
+# sys.path.insert(0, os.path.abspath('.'))
+
+
+# -- Project information -----------------------------------------------------
+
+project = 'Fornax Documentation'
+copyright = '2023-2024, Fornax developers'
+author = 'Fornax developers'
+
+
+# -- General configuration ---------------------------------------------------
+
+# Add any Sphinx extension module names here, as strings. They can be
+# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
+# ones.
+extensions = [
+    'myst_nb',
+    'sphinx_copybutton',
+]
+
+# Add any paths that contain templates here, relative to this directory.
+templates_path = ['_templates']
+
+# List of patterns, relative to source directory, that match files and
+# directories to ignore when looking for source files.
+# This pattern also affects html_static_path and html_extra_path.
+exclude_patterns = ['_build', 'notes', '.tox', '.tmp', '.pytest_cache']
+
+# MyST-NB configuration
+nb_execution_timeout = 900
+
+# -- Options for HTML output -------------------------------------------------
+
+# The theme to use for HTML and HTML Help pages.  See the documentation for
+# a list of builtin themes.
+#
+html_theme = 'sphinx_book_theme'
+html_title = 'Fornax Demo Notebooks'
+html_logo = '_static/fornax_logo.png'
+html_theme_options = {
+    "github_url": "https://github.com/nasa-fornax/fornax-documentation",
+    "repository_url": "https://github.com/nasa-fornax/fornax-documentation",
+    "repository_branch": "main",
+    "use_repository_button": True,
+    "use_issues_button": True,
+    "use_edit_page_button": True,
+    "home_page_in_toc": True,
+}
+
+
+# Add any paths that contain custom static files (such as style sheets) here,
+# relative to this directory. They are copied after the builtin static files,
+# so a file named "default.css" will overwrite the builtin "default.css".
+html_static_path = ['_static']
+
+# myst configurations
+myst_heading_anchors = 4

--- a/index.md
+++ b/index.md
@@ -1,0 +1,8 @@
+# User Documentation
+
+```{toctree}
+---
+maxdepth: 2
+---
+
+README

--- a/site-requirements.txt
+++ b/site-requirements.txt
@@ -1,0 +1,4 @@
+sphinx
+myst-nb
+sphinx-book-theme
+sphinx-copybutton

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,21 @@
+[tox]
+envlist =
+    py{311}-buildhtml
+requires =
+    pip >= 19.3.1
+
+[testenv]
+
+description = run tests and build html
+
+deps =
+    # We use these files to specify all the dependencies, and below we override
+    # versions for specific testing scenarios
+    buildhtml: -rsite-requirements.txt
+
+commands =
+    pip freeze
+
+    buildhtml: sphinx-build -b html . _build/html -D nb_execution_mode=off -nT --keep-going
+
+skip_install = true


### PR DESCRIPTION
While we deploy this documentation along with the notebooks, I think it would be useful to have a CI job here, too to show how the content would render. 

We can then also add other checks relevant to narrative documentation, e.g. linkchecking on the URLs, spellchecker, etc.

(My main motivation to get this is sooner rather than later to have a preview for #39 where I wasn't confident if the code blocks would require extra empty lines around the block or not for rendering)