### PR TITLE
Document git set up and port access

### DIFF
--- a/documentation/compute_environments.md
+++ b/documentation/compute_environments.md
@@ -73,3 +73,36 @@ The front-end extension can be installed after jupyterlab starts, and can show u
 Note: Extensions that include a server-side component cannot be installed by individual users because they must be installed before JupyterLab starts. In that case, please open a request in the [Fornax Community Forum](https://discourse.fornax.sciencecloud.nasa.gov/) "Support" category.
 To install additional software, there are two options:
 
+## How can I use git?
+
+If you are using git for the first time, you will need to set up your git.
+Before starting these steps, make sure you have a git account and an access token.
+Then from within the Fornax Science Console, open a terminal and run the following commands:
+
+```sh
+git config --global credential.helper cache
+git clone https://your repo/
+
+# << make changes >>
+
+git add changed.file
+git commit -m "testing"
+
+enter git username:
+enter git token:
+
+git push
+```
+
+### Can I use ssh instead of https?
+
+We are sorry, but ssh is not supported in the Fornax Science Console.
+
+## I am trying to access a web service and it is not working
+
+If you are trying to access a web service and it is not working, it may be due to it not running on standard http or https ports.
+The Fornax ScienceConsole only allows access to web services running on ports 80 and 443.
+
+## How do I access a web service running on a different port?
+
+You can raise an issue in the Fornax Helpdesk and we will try to help you.

--- a/documentation/compute_environments.md
+++ b/documentation/compute_environments.md
@@ -101,7 +101,7 @@ We are sorry, but ssh is not supported in the Fornax Science Console.
 ## I am trying to access a web service and it is not working
 
 If you are trying to access a web service and it is not working, it may be due to it not running on standard http or https ports.
-The Fornax ScienceConsole only allows access to web services running on ports 80 and 443.
+The Fornax Science Console only allows access to web services running on ports 80 and 443.
 
 ## How do I access a web service running on a different port?
 

--- a/documentation/compute_environments.md
+++ b/documentation/compute_environments.md
@@ -67,7 +67,7 @@ python -m ipykernel install --name myenv --user
 ```
 The kernel should show up in the jupyterlab main launcher page and in the kernel selection dropdown menu inside a running notebook.
 
-**Note**: It is recommended that you remove user environments that are no longer needed, as they may deplete you home storage.
+**Note**: It is recommended that you remove user environments that are no longer needed, as they may deplete your home storage.
 
 ## Installing Extensions on the Fornax Science Console
 
@@ -75,36 +75,17 @@ There are two types Jupyerlab extensions. Front-end (menus etc), and server exte
 The front-end extension can be installed after jupyterlab starts, and can show up if you refresh the page, as long they are installed in the environment running jupyterlab.
 Note: Extensions that include a server-side component cannot be installed by individual users because they must be installed before JupyterLab starts. In that case, please open a request in the [Fornax Community Forum](https://discourse.fornax.sciencecloud.nasa.gov/) "Support" category.
 
-## How can I use git?
+## Using Git
 
-If you are using git for the first time, you will need to set up your git.
-Before starting these steps, make sure you have a git account and an access token.
-Then from within the Fornax Science Console, open a terminal and run the following commands:
+You must use HTTPS to authenticate with `git` on the Fornax Science Console.
+SSH is not supported.
+This means you will need to enter your username and password (or token) when interacting with a remote.
+To reduce the number of times you need to enter them, you can configure `git` to cache them by opening a terminal and running the following command:
 
 ```sh
+# Tell git to cache your credentials for all repos.
+# To do this for a single repo instead, cd into the repo directory and remove '--global' before running the command.
 git config --global credential.helper cache
-git clone https://your repo/
-
-# << make changes >>
-
-git add changed.file
-git commit -m "testing"
-
-enter git username:
-enter git token:
-
-git push
 ```
 
-### Can I use ssh instead of https?
-
-We are sorry, but ssh is not supported in the Fornax Science Console.
-
-## I am trying to access a web service and it is not working
-
-If you are trying to access a web service and it is not working, it may be due to it not running on standard http or https ports.
-The Fornax Science Console only allows access to web services running on ports 80 and 443.
-
-## How do I access a web service running on a different port?
-
-You can raise an issue in the Fornax Helpdesk and we will try to help you.
+For more information about using `git`, see https://git-scm.com/docs/gittutorial.

--- a/documentation/compute_environments.md
+++ b/documentation/compute_environments.md
@@ -41,6 +41,9 @@ The **uv**-based environments use [uv](https://docs.astral.sh/uv/) to manage the
 The `conda`-based environments are used when packages that are not `pip`-installable. Examples this include `heasoft` and `ciao` in the high-energy container image. These are activated with `conda activate {env-name}` and deactivated with `conda deactivate`. These are installed under `$CONDA_DIR/envs`
 
 ## Installing additional software on the Fornax Science Console
+
+To install additional software, there are two options:
+
 1. Add to a current environment:
 To add packages to a currently installed environment, you install them with `pip` (or the faster `uv pip`) after activating the relevant environment.
     - Inside a notebook running the relevant environment, run `!uv pip install ...`, passing the extra packaged needed.
@@ -71,7 +74,6 @@ The kernel should show up in the jupyterlab main launcher page and in the kernel
 There are two types Jupyerlab extensions. Front-end (menus etc), and server extensions. Most extensions include both components.  Instructions on how to find and install extensions can be found at [JupyterLab: Extensions](https://jupyterlab.readthedocs.io/en/stable/user/extensions.html). 
 The front-end extension can be installed after jupyterlab starts, and can show up if you refresh the page, as long they are installed in the environment running jupyterlab.
 Note: Extensions that include a server-side component cannot be installed by individual users because they must be installed before JupyterLab starts. In that case, please open a request in the [Fornax Community Forum](https://discourse.fornax.sciencecloud.nasa.gov/) "Support" category.
-To install additional software, there are two options:
 
 ## How can I use git?
 

--- a/documentation/forsc_troubleshooting.md
+++ b/documentation/forsc_troubleshooting.md
@@ -13,3 +13,16 @@ The Science Console is currently intended for interactive use and will cull sess
 See the {ref}`jupyterlab-session-information` section for details.
 
 how long is the period of inactivity that gets culled? 15 minutes.
+
+## Can I use SSH instead of HTTPS?
+
+SSH is not supported on the Fornax Science Console at this time.
+
+## I am trying to access a web service and it is not working
+
+If you are trying to access a web service and it is not working, it may be due to it not running on standard HTTP or HTTPS ports.
+The Fornax Science Console only allows access to web services running on ports 80 and 443.
+
+## How do I access a web service running on a different port?
+
+Please open a new topic in the Fornax Community Forum "Support" category to ask for help.


### PR DESCRIPTION
Closes #79 

Content copied from https://discourse.fornax.sciencecloud.nasa.gov/t/blocking-outbound-ports/76/3.