### PR TITLE
Add glossary skeleton

### DIFF
--- a/documentation/glossary.md
+++ b/documentation/glossary.md
@@ -1,0 +1,9 @@
+# Glossary
+
+:::{glossary}
+
+ForSC
+: The Fornax Science Console (ForSC) is a NASA-funded web-based application that provides access to cloud computing via JupyterLab.
+See [What is the Fornax Science Console?](documentation/intro_forsc.md).
+
+:::

--- a/documentation/intro_forsc.md
+++ b/documentation/intro_forsc.md
@@ -1,6 +1,6 @@
 # What is the Fornax Science Console?
 
-The Fornax Science Console (ForSC) is a NASA-funded web-based application that provides access to a limited amount of cloud computing via JupyterLab, which offers access to Jupyter Notebooks, Jupyter Console, and the terminal (command line). Users must register to login to the system, but usage is free. Once logged in, users will have access to data sets curated by repositories around the world, and can upload moderate amounts of private data. To get started quickly, users can choose from a variety of example Jupyter notebooks as well as pre-installed software environments. These can be modified to suit user needs.
+The Fornax Science Console ({term}`ForSC`) is a NASA-funded web-based application that provides access to a limited amount of cloud computing via JupyterLab, which offers access to Jupyter Notebooks, Jupyter Console, and the terminal (command line). Users must register to login to the system, but usage is free. Once logged in, users will have access to data sets curated by repositories around the world, and can upload moderate amounts of private data. To get started quickly, users can choose from a variety of example Jupyter notebooks as well as pre-installed software environments. These can be modified to suit user needs.
 
 The Fornax Science Console supports many astronomical use cases, but users will find it especially beneficial for analyses:
 


### PR DESCRIPTION
Skeleton for #77 

I added a basic glossary page. Still need to see what it looks like rendered to check if I did it right. I haven't built it locally yet because I need to track down dependencies.