### PR TITLE
Improve presentation of server and environment options

### DIFF
--- a/documentation/compute_environments.md
+++ b/documentation/compute_environments.md
@@ -1,14 +1,13 @@
+(compute-environments)=
 # Compute Environments
 
-The Fornax Science Console offers several Software environments, they are currently grouped into two containers:
+The Fornax Science Console offers {ref}`Base Environments <base-environment>` which you can select by choosing a container image when starting your server.
+Each base environment comes pre-installed with one or more specific software environments (or simply, "environments").
+You can customize your environment by installing additional software and extensions.
 
--   **Default Astrophysics** (recommended for most use cases) contains many common astronomy software, including those required to run the demo notebooks.
-    This container image is referred to as **fornax-main**.
--   **High-Energy Astrophysics** contains high-energy software, which currently includes HEASoft.
-    Plans exist to add CIAO, XMM-SAS and Fermitools.
-    This container image is referred to as **fornax-hea**.
+## View Pre-installed Software
 
-There are two ways to view the software pre-installed in the containers:
+There are two ways to view the pre-installed environments and software that come with each container:
 
 -   **Inside the Console**:
     The list of environment files (`*.yml` for conda and `requirements-*.txt` for uv) of all the installed environments can be found in the folder `$LOCK_DIR`.
@@ -25,7 +24,7 @@ There are two ways to view the software pre-installed in the containers:
 It has general astronomy and plotting software.
 
 Each of the Fornax demo notebooks has its own environment with a name of the form `py-{notebook-name}` (e.g. `py-light_curve_collector` and `py-multiband_photometry`).
-Each environment has the packages required to run the notebook  pre-installed.
+Each environment has the packages required to run the notebook pre-installed.
 When opening the notebook, the corresponding kernel should automatically start.
 You can also select it from the drop down kernel menu at the top-right of an open notebook.
 

--- a/documentation/forsc_server_options.md
+++ b/documentation/forsc_server_options.md
@@ -1,6 +1,6 @@
 # Server and Environment Options
 
-Once you have logged in to the Fornax Science Console (ForSC), you will be asked to specify a **Server Type** and an **Environment**, as shown in the screenshot below.
+Once you have logged in to the Fornax Science Console ({term}`ForSC`) and clicked "JupyterHub" to start a server (see {ref}`quick-start`), you will be asked to specify a **Server Type** and a base **Environment**, as shown in the screenshot below.
 
 ```{figure} ../_static/forsc_jupyterlab_servers.png
 :alt: JupyterLab server options menu as deployed in the Fornax Science Console
@@ -33,10 +33,17 @@ You do not need approval for stopping and restarting your instance as long as yo
 However, if you require additional time beyond your estimate, please notify us by posting a brief justification to your topic.
 If your analysis exceeds the estimated runtime, we may reach out to discuss potential termination.
 
-## Environment
+(base-environment)=
+## Base Environment
 
 The Fornax Science Console offers a number of software environments to choose from.
-These include:
+They are currently grouped into two base environments.
+You can select a base environment by choosing one of the following container images from the "Environment" dropdown in the screenshot above:
 
--   **Default Astrophysics** *(recommended for most users)* This software environment
--   **High-Energy Astrophysics**
+-   **Default Astrophysics** (recommended for most use cases) contains many common astronomy software, including those required to run the demo notebooks.
+    This container image is referred to as **fornax-main**.
+-   **High-Energy Astrophysics** contains high-energy software, which currently includes HEASoft.
+    Plans exist to add CIAO, XMM-SAS and Fermitools.
+    This container image is referred to as **fornax-hea**.
+
+See {ref}`compute-environments` for more information about the specific software environments that are pre-installed in each container image and how to customize your environment after your server starts up.

--- a/documentation/forsc_server_options.md
+++ b/documentation/forsc_server_options.md
@@ -10,7 +10,7 @@ JupyterLab Server options on ForSC.
 
 ## Server Type
 
-The Fornax Science Console offers three server types: **Standard**, **Large**, and **XLarge**.
+The Fornax Science Console offers four server types: **Small**, **Medium**, **Large**, and **XLarge**.
 Basic specifications for each are described in the {ref}`intro-best-practices` section.
 
 Compute resources on Fornax are cloud-based and funded by NASA.

--- a/documentation/forsc_server_options.md
+++ b/documentation/forsc_server_options.md
@@ -1,3 +1,4 @@
+(server-and-env-options)=
 # Server and Environment Options
 
 Once you have logged in to the Fornax Science Console ({term}`ForSC`) and clicked "JupyterHub" to start a server (see {ref}`quick-start`), you will be asked to specify a **Server Type** and a base **Environment**, as shown in the screenshot below.

--- a/documentation/intro_fornax_resources.md
+++ b/documentation/intro_fornax_resources.md
@@ -3,7 +3,7 @@
 
 The Fornax Science Console offers three choices for compute capacity:
 
--   **small** (4 GB RAM, 2 CPUs): Ideal for exploratory or prototype work.
+-   **Small** (4 GB RAM, 2 CPUs): Ideal for exploratory or prototype work.
     With no usage time constraints, this is the best place to start developing.
 -   **Medium** (16GB RAM, 4CPUs): This is a good server size to test workflows.
 -   **Large** (64 GB RAM, 16 CPUs): Suited for tested and parallelized workflows.

--- a/documentation/intro_fornax_resources.md
+++ b/documentation/intro_fornax_resources.md
@@ -1,7 +1,13 @@
 (intro-best-practices)=
 # Fornax Resources and Best Practices
 
-The Fornax Science Console offers three choices for compute capacity:
+Cloud compute is billed to NASA on an hourly basis—even when resources are idle.
+Likewise, storage is charged based on the amount allocated, not the amount actively used.
+To ensure efficient allocation of these limited resources across the community, users are encouraged to use the least amount of compute and storage necessary to accomplish their tasks.
+
+## Computing Resources
+
+The Fornax Science Console offers four choices for compute capacity:
 
 -   **Small** (4 GB RAM, 2 CPUs): Ideal for exploratory or prototype work.
     With no usage time constraints, this is the best place to start developing.
@@ -11,12 +17,12 @@ The Fornax Science Console offers three choices for compute capacity:
 -   **XLarge** (512 GB RAM, 128 CPUs): Reserved for the most demanding, highly parallel jobs.
     Available by approval only and intended for limited, efficient use of roughly 100 hours in a given year.
 
+See {ref}`server-and-env-options` for more information.
+
+## Storage Resources
+
 Fornax also offers three types of storage:
 
 -   **Persistent home directory:** Each user has a 10 GB home directory on the file system for storing important files that need to be saved long term.
 -   **Short-term scratch space:** Users can request up to 5 TB of temporary space on the file system, available for up to two weeks, for files needed only during active work.
 -   **Extended temporary storage:** For project work lasting several months, users can request up to 5 TB of object storage on S3, intended for data that doesn’t require fast file system access and won’t be stored permanently.
-
-Cloud compute is billed to NASA on an hourly basis—even when resources are idle.
-Likewise, storage is charged based on the amount allocated, not the amount actively used.
-To ensure efficient allocation of these limited resources across the community, users are encouraged to use the least amount of compute and storage necessary to accomplish their tasks.

--- a/documentation/intro_quick_start.md
+++ b/documentation/intro_quick_start.md
@@ -1,3 +1,4 @@
+(quick-start)=
 # Quick Start Guide
 
 The Fornax Science Console is a robust tool for scientific research.

--- a/documentation/intro_quick_start.md
+++ b/documentation/intro_quick_start.md
@@ -27,42 +27,42 @@ After logging in, you will see a Resource Dashboard.
 You can learn more about it in the {ref}`forsc-dashboard` section.
 For now, go to the left-hand menu and choose JupyterHub under Compute.
 
-## 4. Select a Server Type
+## 4. Select a Server Type and Environment
 
-You’ll be prompted to select the size of the compute instance.
-Please choose **Small** until you have carefully read the {ref}`intro-best-practices` section.
+You’ll be prompted to select the following:
 
-## 5. Select a Software Environment
+-   **Server Type**: Size of the compute instance.
+    Please choose **Small** until you have carefully read the {ref}`intro-best-practices` section.
+-   **Environment**: Container image providing your base environment.
+    The **Default Astrophysics** environment is recommended for most use cases.
+    {ref}`base-environment` describes the options in more detail.
 
-Choose the **Default Astrophysics** environment unless you know that you have a particular need for one of the others.
+## 5. Launch JupyterLab
 
-## 6. Launch JupyterLab
-
-Click **Start** to launch the environment.
+Click **Start** to launch the base environment.
 It is normal for JupyterLab to take a couple of minutes to start.
 At this point, the server you have chosen will begin accruing cost, even though you have not started any computations.
 Since you have chosen the **Small** server, this cost will be low.
 
-## 7. Open a New Notebook
+## 6. Open a New Notebook
 
 In JupyterLab, you will see a main menu at the top, your persistent home directory on the left, and a work area on the right.
+The Launcher tab is open in the work area by default.
+You can click the **+** to the right of the tab name just under the main menu to open a new Launcher tab at any time.
 
--   Click the **blue +** just under the main menu.
-    This will open a new Launcher tab in the work area.
 -   In the Launcher tab, select **notebook** under the **Notebook** section.
     A new notebook tab will open in the work area.
 -   When you are ready to save your work to your Fornax home directory, click on the **Save** icon in the notebook tab.
 -   To download your notebook to your local machine, click on your notebook in your home directory on the left side of the screen.
     Then go to the main menu and select **File** → **Download**.
 
-## 8. Shut Down Your Server
+## 7. Shut Down Your Server
 
-When you are done with your work session, you must shut down the Standard server you launched.
+When you are done with your work session, you must shut down the server you launched.
 
-In the main menu, choose **File** → **Hub Control Panel**.
+-   In the main menu, choose **File** → **Hub Control Panel**.
+-   In the new JupyterHub browser tab that opens, click on the red button labeled **Stop My Server**.
 
-In the new JupyterHub browser tab that opens, click on the red button labeled **Stop My Server**.
-
-## 9. Logout
+## 8. Logout
 
 Click **Logout** in the upper right corner of the new browser JupyterHub tab.


### PR DESCRIPTION
IMPORTANT: Merge _after_ #107. This PR is ready to review but I'm leaving it as a draft to avoid it being accidentally merged prematurely. #107 needs to go first and then I may need to resolve conflicts here.

This PR does the following two things in an attempt to improve the presentation of the server type and environment information. I'm not necessarily attached to the particular solutions I came up with for this PR, but I do feel that our current usage of the term "environment" and our overall organization of this content is confusing and needs some help. Happy to change or even drop this PR if others have better ideas.

1. Call the full container environments "base environments" to avoid confusion with the individual conda/uv environments contained therein. It's totally reasonable to use the term "environment" for both, but they are very different things so we should be clear about which we're referring to. An alternative option would be to completely avoid using the term "environment" for the former, but then I'd strongly suggest that we change the JupyterHub startup page where the user has to select an "Environment" == container image.
2. Do the following to make the server type and (base) environment content more clear (at least to me):
    - Minor reorganization. Most notably, move the container definitions from [Compute Environments](https://nasa-fornax.github.io/fornax-documentation/compute-environments) to [Server and Environment Options](https://nasa-fornax.github.io/fornax-documentation/forsc-server-options) to avoid duplication.
    - Add cross-links between the various pages holding server and environment info.
    - Clean up. For example, make sure all four server types are included, update quick start instructions, etc.