### PR TITLE
Minor text updates to finish several open issues

### DIFF
--- a/documentation/data_access.md
+++ b/documentation/data_access.md
@@ -9,6 +9,7 @@ By combining these data access options with Fornax's integrated compute resource
 The **JupyterLab File Browser** includes an **Upload File** option, allowing users to transfer data files from their local machine directly into your Fornax Science Console home directory.
 Once uploaded, these files are available for immediate use in your analysis, whether in Jupyter Notebooks or other tools.
 You can organize and manage files through the File Browser interface, view directory structures, and access the uploaded datasets for use with Python libraries, APIs, or the compute resources provided by Fornax.
+If you need the full path to a file or directory you have uploaded, find it using the File Browser interface, then right-click on it and select "Copy Path".
 
 ## Direct Cloud Access
 

--- a/documentation/data_access.md
+++ b/documentation/data_access.md
@@ -1,8 +1,9 @@
 # Data Access from within Fornax
 
-The Fornax Science Console provides multiple data access pathways, including direct file uploads, direct cloud access, and support for IVOA-compliant application program interfaces(APIs).
+The Fornax Science Console provides multiple data access pathways, including direct file uploads, direct cloud access, and support for IVOA-compliant application program interfaces (APIs).
 Users can also leverage Python libraries such as Astroquery and PyVO to programmatically access major astrophysics archives, including the NASA Astrophysics Archives: HEASARC, IRSA, and MAST.
 By combining these data access options with Fornax's integrated compute resources, users can streamline the process of retrieving, analyzing, and processing astrophysical data, making complex analyses more efficient and accessible.
+To understand data storage options on the Fornax Science Console, see {ref}`intro-best-practices`.
 
 ## Direct File Uploads
 

--- a/documentation/data_access.md
+++ b/documentation/data_access.md
@@ -2,6 +2,7 @@
 
 The Fornax Science Console provides multiple data access pathways, including direct file uploads, direct cloud access, and support for IVOA-compliant application program interfaces (APIs).
 Users can also leverage Python libraries such as Astroquery and PyVO to programmatically access major astrophysics archives, including the NASA Astrophysics Archives: HEASARC, IRSA, and MAST.
+
 By combining these data access options with Fornax's integrated compute resources, users can streamline the process of retrieving, analyzing, and processing astrophysical data, making complex analyses more efficient and accessible.
 To understand data storage options on the Fornax Science Console, see {ref}`intro-best-practices`.
 

--- a/documentation/forsc_dashboard.md
+++ b/documentation/forsc_dashboard.md
@@ -21,3 +21,5 @@ The Fornax Science Console Dashboard
 -   **Compute Spend** tracks the total number of dollars spent on compute so far this calendar year.
 -   **Running Jupyter Servers** this is 0 if you are not running a compute environment, or 1 if you are.
     Note there is a delay in this value of about 1-2 minutes, so if you shut down your server, you will have to wait a bit before this number shows the update.
+
+To see changes, you can reload the Dashboard at any time without affecting a server you may have running, but note that there may be a delay of up to a few minutes before recent usage is reflected.

--- a/documentation/forsc_jupyterlab.md
+++ b/documentation/forsc_jupyterlab.md
@@ -42,7 +42,11 @@ Below we discuss some of the tools available via the **Launcher**.
 
 **Terminal** provides a command line, which allows users to run Emacs or vi .
 
-2. **Dask**
+2. **Running Terminals and Kernels**
+
+Monitors and manages active processes in your JupyterLab environment, such as running notebooks, terminals, and associated kernels.
+
+3. **Dask**
 
 Dask is a Python library for parallel computing.
 The Fornax Science Console includes the Dask JupyterLab Extension which can be used to manage a Dask cluster and monitor the progress of submitted functions.
@@ -55,15 +59,15 @@ You can drag and drop the tab to move it somewhere else on the screen.
 
 Start or restart the kernel for the notebook you’re working in so that it will recognize the cluster.
 
-3. **Git**
+4. **Git**
 
 This extension integrates Git version control into the JupyterLab interface, enabling you to stage, commit, push, and pull notebook and code changes without leaving the environment.
 It provides visual diffs, branch management, and history browsing, making collaborative development and reproducibility seamless.
 
-4. **Table of Contents**
+5. **Table of Contents**
 Automatically generates a sidebar outline of all headings in your notebook or document, allowing you to quickly navigate between sections.
 
-5. **Extensions Manager**
+6. **Extensions Manager**
 
 Shows installed extensions and lets you manage them.
 
@@ -78,15 +82,12 @@ Shows metadata, configuration options, or properties for the currently selected 
 2. **Kernel Usage**
 
 In JupyterLab, a kernel is the computational engine that executes your code.
+It is connected to an environment with installed software.
 When you open a notebook or console in JupyterLab, it connects to a kernel that runs the code you write, keeps track of variables, and returns output (such as plots, results, or errors) back to the interface.
 
 The Kernel Usage tool monitors resources (such as CPU and memory) being used by your Jupyter kernel.
 
-3. **Running Terminals and Kernels**
-
-Monitors and manages active processes in your JupyterLab environment, such as running notebooks, terminals, and associated kernels.
-
-4. **Debugger**
+3. **Debugger**
 
 Allows you to step through your code to identify bugs, understand the flow of execution, and troubleshoot issues in real-time by providing features like breakpoints, variable inspection, and call stacks.
 

--- a/documentation/forsc_troubleshooting.md
+++ b/documentation/forsc_troubleshooting.md
@@ -6,7 +6,7 @@ If you have a running job and your internet is disrupted, the job should continu
 You can connect to a running session using the same browser or different browser.
 You can even connect to the same session from different machines.
 
-## How will my analysis be affected by memory limitations?
+## How will my analysis be affected by CPU and memory limitations?
 
 If your workload exceeds your server size, your server may be allowed to use additional resources temporarily.
 This can be convenient but should not be relied on.

--- a/documentation/intro_fornax_resources.md
+++ b/documentation/intro_fornax_resources.md
@@ -26,3 +26,6 @@ Fornax also offers three types of storage:
 -   **Persistent home directory:** Each user has a 10 GB home directory on the file system for storing important files that need to be saved long term.
 -   **Short-term scratch space:** Users can request up to 5 TB of temporary space on the file system, available for up to two weeks, for files needed only during active work.
 -   **Extended temporary storage:** For project work lasting several months, users can request up to 5 TB of object storage on S3, intended for data that doesn’t require fast file system access and won’t be stored permanently.
+
+You are also welcome to "bring your own storage".
+This may be anything that you can access using an API, such as an AWS S3 or Google Cloud Storage bucket, Google Drive, Box, etc.

--- a/documentation/intro_fornax_resources.md
+++ b/documentation/intro_fornax_resources.md
@@ -21,10 +21,9 @@ See {ref}`server-and-env-options` for more information.
 
 ## Storage Resources
 
-Fornax also offers three types of storage:
+The Fornax Science Console offers two types of storage:
 
 -   **Persistent home directory:** Each user has a 10 GB home directory on the file system for storing important files that need to be saved long term.
--   **Short-term scratch space:** Users can request up to 5 TB of temporary space on the file system, available for up to two weeks, for files needed only during active work.
 -   **Extended temporary storage:** For project work lasting several months, users can request up to 5 TB of object storage on S3, intended for data that doesn’t require fast file system access and won’t be stored permanently.
 
 You are also welcome to "bring your own storage".

--- a/documentation/python_notebooks.md
+++ b/documentation/python_notebooks.md
@@ -8,10 +8,10 @@ Once tested, these notebooks are [rendered into HTML](https://nasa-fornax.github
 
 ## Notebooks in the Console
 
-When you login to the console, the notebooks available in `/opt/notebooks`, which is linked in the user's home directory as `~/fornax-notebook`.
+When you login to the console, the tutorial notebooks are available in your home directory at `~/fornax-notebooks`.
 
 As the notebooks are continuously developed, the clone in the console can lag behind.
-To get the latest version of the notebooks, run the `update-notebooks.sh` script from the terminal.
+To get the latest version of the notebooks, open a terminal and run `update-notebooks.sh`.
 
 Note that the notebooks directory is reset with every session.
 if you want to make modifications to the notebooks, make you own copy or clone and modify it.


### PR DESCRIPTION
Closes #33. Closes #25. Closes #36. Closes #22. Closes #17.

- Remove 'Short-term scratch space' since it's not available yet. https://github.com/nasa-fornax/fornax-documentation/issues/25#issuecomment-3219981938
- Document how to get the absolute path to an uploaded file. 
- Mention "bring your own storage" options.
- Add cross-links
- Add info about making the dashboard update. #60.
- Update notebook update instructions.
- Clarify resource limitations.
- Update kernel description