### PR TITLE
Add vscode info

### DIFF
--- a/documentation/forsc_jupyterlab.md
+++ b/documentation/forsc_jupyterlab.md
@@ -36,7 +36,10 @@ This includes the **Launcher**(blue plus sign), **New Folder** (folder symbol wi
 The **Launcher** will open a panel in the main area that provides clickable tiles for quickly starting new tools, such as notebooks and terminals.
 Below we discuss some of the tools available via the **Launcher**.
 
-**Visual Studio Code (VS Code)** is an integrated development environment(IDE) widely used for programming in many languages—including Python, JavaScript, C++, and more.
+**VS Code** will open a new window where you can work in a web-based integrated development environment (IDE).
+It is powered by [openvscode-server](https://github.com/gitpod-io/openvscode-server) which runs [Visual Studio Code - Open Source](https://github.com/microsoft/vscode) in a remote environment.
+See those links for more information.
+Note: Microsoft-specific customizations like GitHub Copilot are only available in Microsoft's desktop version of VS Code and so cannot be accessed here.
 
 **Firefly** is a visualization platform designed to facilitate interactive exploration of astronomical data, including images, catalogs, and plots, through a modern, browser-based interface.
 


### PR DESCRIPTION
Closes #56 

Adds a little info about the VS Code extension and provides links where people can learn more about it. We don't plan to document extensions in detail but questions about this one have come up a few times now so I tracked down a few details to try to help answer them.