### PR TITLE
Quickly added more information on which high-energy envs are available to 'server_options.md'

### DIFF
--- a/documentation/compute_environments.md
+++ b/documentation/compute_environments.md
@@ -15,6 +15,7 @@ The front-end extension can be installed after JupyterLab starts, and can show u
 Note: Extensions that include a server-side component cannot be installed by individual users because they must be installed before JupyterLab starts.
 In that case, please open a request in the [Fornax Community Forum](https://discourse.fornax.sciencecloud.nasa.gov/) "Support" category.
 
+(compute-environments-select-python)=
 ## Select a Python Environment
 
 `python3` is the default python {term}`environment <environment>`.

--- a/documentation/compute_environments.md
+++ b/documentation/compute_environments.md
@@ -8,7 +8,7 @@ You can customize your experience by installing additional extensions and softwa
 ## Install a New Extension
 
 There are two types of JupyterLab extensions.
-Front-end (menus etc), and server extensions.
+Front-end (menus etc.), and server extensions.
 Most extensions include both components.
 Instructions on how to find and install extensions can be found at [JupyterLab: Extensions](https://jupyterlab.readthedocs.io/en/stable/user/extensions.html).
 The front-end extension can be installed after JupyterLab starts, and can show up if you refresh the page, as long they are installed in the environment running JupyterLab (/opt/jupyter/).
@@ -23,7 +23,7 @@ It has general astronomy and plotting software.
 Each of the Fornax demo notebooks has its own environment with a name of the form `py-{notebook-name}` (e.g. `py-light_curve_collector` and `py-multiband_photometry`).
 Each environment has the packages required to run the notebook pre-installed (see {ref}`view-preinstalled-software`).
 When opening the notebook, the corresponding {term}`kernel <kernel>` should automatically start.
-You can also select it from the drop down kernel menu at the top-right of an open notebook.
+You can also select it from the drop-down kernel menu at the top-right of an open notebook.
 
 To activate a specific environment from the {term}`terminal <terminal>`, run: `source $ENV_DIR/{environment-name}/bin/activate`.
 For example, to activate the `py-light_curve_classifier` environment, run:

--- a/documentation/server_options.md
+++ b/documentation/server_options.md
@@ -20,8 +20,8 @@ Being mindful of usage helps ensure that the platform remains sustainable and ac
 Please follow these guidelines:
 
 **Start small:** Begin by testing your workflow on the smallest server that meets your needs.
-Limit initial runs in scope (e.g., fewer sources, shorter iterations, smaller datasets).
-Scale up to a larger server or full analysis only after verifying that your code runs successfully at smaller scale.
+Limit initial runs in scope (e.g. fewer sources, shorter iterations, smaller datasets).
+Scale up to a larger server or full analysis only after verifying that your code runs successfully at a smaller scale.
 
 **Shut down when done**:
 Having an active compute instance—even if you're not currently running code—still consumes resources and counts against your allocation.
@@ -41,10 +41,19 @@ The Fornax Science Console offers a number of software {term}`environments <envi
 They are currently grouped into two base environments.
 You can select a base environment by choosing one of the following container images from the "Environment" dropdown in the screenshot above:
 
--   **Default Astrophysics** (recommended for most use cases) contains many common astronomy software, including those required to run the demo notebooks.
-    This container image is referred to as **fornax-main**.
--   **High-Energy Astrophysics** contains high-energy software, which currently includes HEASoft.
-    Plans exist to add CIAO, XMM-SAS and Fermitools.
-    This container image is referred to as **fornax-hea**.
+(base-environment-default)=
+### **Default Astrophysics**
+The base Fornax container will be sufficient for many use cases, and provides a pre-installed set of commonly used astronomy tools. This includes the Python environments (managed with _uv_; see {ref}`compute-environments`) required to run the demonstration notebooks.
+
+This container image is referred to as **fornax-main** - *please note that there is currently also a `Dev Astrophysics' environment option, and we do not recommend its use unless suggested by the support team.*
+    
+
+(base-environment-hea)=
+### **High-Energy Astrophysics**
+-    - contains software required for the analysis of high-energy observations.
+    , and currently provides pre-installed HEASoft, CIAO, and FermiPy environments. 
+      Plans exist to add CIAO, XMM-SAS and Fermitools.
+      
+ This container image is referred to as **fornax-hea** - *please note that there is currently also a `Dev High-Energy Astrophysics' environment option, and we do not recommend its use unless suggested by the support team.*
 
 See {ref}`compute-environments` for more information about the specific software environments that are pre-installed in each container image and how to customize your environment after your server starts up.

--- a/documentation/server_options.md
+++ b/documentation/server_options.md
@@ -43,17 +43,35 @@ You can select a base environment by choosing one of the following container ima
 
 (base-environment-default)=
 ### **Default Astrophysics**
-The base Fornax container will be sufficient for many use cases, and provides a pre-installed set of commonly used astronomy tools. This includes the Python environments (managed with _uv_; see {ref}`compute-environments`) required to run the demonstration notebooks.
+- The base Fornax container will be sufficient for many use cases, and provides a pre-installed set of commonly used astronomy tools. This includes the Python environments (managed with _uv_; see {ref}`compute-environments`) required to run the demonstration notebooks.
 
-This container image is referred to as **fornax-main** - *please note that there is currently also a `Dev Astrophysics' environment option, and we do not recommend its use unless suggested by the support team.*
-    
+- This container image is referred to as **fornax-main** - *please note that there is currently also a `Dev Astrophysics' environment option, and we do not recommend its use unless suggested by the support team.*
+
+When a default astrophysics Fornax instance has been launched, the existing software environments can be activated by following the instructions provided in - {ref}`compute-environments-select-python`.
 
 (base-environment-hea)=
 ### **High-Energy Astrophysics**
--    - contains software required for the analysis of high-energy observations.
-    , and currently provides pre-installed HEASoft, CIAO, and FermiPy environments. 
-      Plans exist to add CIAO, XMM-SAS and Fermitools.
-      
- This container image is referred to as **fornax-hea** - *please note that there is currently also a `Dev High-Energy Astrophysics' environment option, and we do not recommend its use unless suggested by the support team.*
+- The second base environment contains pre-installed versions of software required for the analysis of high-energy (X-ray, Gamma-ray, etc.) observations.
 
+- This container image is referred to as **fornax-hea** - *please note that there is currently also a `Dev High-Energy Astrophysics' environment option, and we do not recommend its use unless suggested by the support team.*
+
+- Fornax-hea currently includes HEASoft, CIAO, and FermiPy environments; XMM-SAS support is under active development, and plans also exist to include an eROSITA-eSASS install.
+
+Once launched, access to Fornax-hea software environments is provided through _micromamba_ (essentially a light-weight replacement for _conda_) environments - you can list available environments with:
+
+```bash 
+micromamba env list
+```
+
+Once you know the name of an environment you want to activate (e.g. *ciao*), you can activate it with:
+
+```bash 
+micromamba activate ciao
+``` 
+Though many pieces of high-energy astrophysics software are not installable through conda/micromamba, the micromamba environments are set up such that, once activated, the software will be activated and usable through the command-line-interface. 
+
+Jupyter Notebooks launched with a high-energy micromamba environment kernel will also initialize the software, allowing (for instance) HEASoft tools to be called in Jupyter cells by prepending '!' to the command. 
+
+---
+ 
 See {ref}`compute-environments` for more information about the specific software environments that are pre-installed in each container image and how to customize your environment after your server starts up.


### PR DESCRIPTION
**Changes - ** Limited in this PR. Split the 'base environment' section into base and hea subsections (essentially how they were already, I just added headers and reference labels), expanded a little on the hea container information particularly, including updating the sentence talking about plans to include CIAO, Fermi, etc., as progress has been made on that front. 

Also included acknowledgements that 'dev' versions of these containers are available in the drop-down, but state that we encourage users to choose non-dev containers. 

Expanded on the activation of hea software environments, as how we have it set up will not be how most people are used to activating those packages.

This is essentially triage, as Tess and I realized there isn't much in main docs about activating HE software - my issue #129 would supersede this by reorganizing information about the compute and software options, but we want something in the production docs quickly.