### PR TITLE
Cleanup JupyterLab page and expand Working with Markdown Notebooks section

### DIFF
--- a/documentation/dashboard.md
+++ b/documentation/dashboard.md
@@ -1,7 +1,7 @@
 (forsc-dashboard)=
 # Dashboard
 
-The purpose of the Fornax Science Console Dashboard is to provide users the status of their compute and storage resource consumption.
+The purpose of the [Fornax Science Console Dashboard](https://console.fornax.sciencecloud.nasa.gov/) is to provide users the status of their compute and storage resource consumption.
 The image below shows a screenshot of the Dashboard.
 
 ```{figure} ../_static/forsc_dashboard.png

--- a/documentation/jupyterlab.md
+++ b/documentation/jupyterlab.md
@@ -24,17 +24,21 @@ This panel may be open by default when a session starts and a new one can be ope
 Many of the tools are standard for JupyterLab and more information about them can be found at the documentation linked above.
 Below we discuss some of the other tools available via the **Launcher**.
 
-**VS Code** will open a new window where you can work in a web-based integrated development environment (IDE).
-It is powered by [code-server](https://github.com/coder/code-server) which runs [Visual Studio Code - Open Source](https://github.com/microsoft/vscode) in a remote environment.
-See those links for more information.
-Note: Microsoft-specific customizations like GitHub Copilot are only available in Microsoft's desktop version of VS Code and so cannot be accessed here.
+VS Code
+:   VS Code will open a new window where you can work in a web-based integrated development environment (IDE).
+    It is powered by [code-server](https://github.com/coder/code-server) which runs [Visual Studio Code - Open Source](https://github.com/microsoft/vscode) in a remote environment.
+    See those links for more information.
+    Note: Microsoft-specific customizations like GitHub Copilot are only available in Microsoft's desktop version of VS Code and so cannot be accessed here.
 
-**Terminal** provides a {term}`command line <terminal>`, which allows users to run Emacs, vi, Python, etc.
+Terminal
+:   Terminal provides a {term}`command line <terminal>`, which allows users to run Emacs, vi, Python, etc.
 
-The **Fornax** section contains links to the {ref}`forsc-dashboard`, documentation (this website), and the {ref}`intro-forum`.
+Fornax
+:   The Fornax section contains links to the {ref}`forsc-dashboard`, documentation (this website), and the {ref}`intro-forum`.
 
-**Firefly** is a visualization platform designed to facilitate interactive exploration of astronomical data, including images, catalogs, and plots, through a modern, browser-based interface.
-See [jupyter_firefly_extensions](https://github.com/Caltech-IPAC/jupyter_firefly_extensions) for more information about this extension, including example notebooks that demonstrate the extension features.
+Firefly
+:   Firefly is a visualization platform designed to facilitate interactive exploration of astronomical data, including images, catalogs, and plots, through a modern, browser-based interface.
+    See [jupyter_firefly_extensions](https://github.com/Caltech-IPAC/jupyter_firefly_extensions) for more information about this extension, including example notebooks that demonstrate the extension features.
 
 ## Menu Bar (Topmost horizontal menu)
 
@@ -51,85 +55,76 @@ This contains dropdown menus like File, Edit, etc., and the *Fornax* menu, which
 
 The left sidebar is a vertical strip of icons, each representing a tool or extension that will open up in the left column of the interface.
 
-1. **File Browser (📁)**
+File Browser (📁)
+:   The File Browser lets you navigate and open files and folders.
+    Double-click a file or .ipynb notebook to open it in the main area.
+    Opening .md files as notebooks should be done by right clicking on the file → "Open With" → "Notebook" so that they display in the expected format with cells of runnable code.
 
-Lets you navigate and open files and folders.
-Double-click a file or .ipynb notebook to open it in the main area.
-Opening .md files as notebooks should be done by right clicking on the file → "Open With" → "Notebook" so that they display in the expected format with cells of runnable code.
+    This includes the **Launcher** (blue plus sign; see above for more information), **New Folder** (folder symbol with plus sign), and **Upload Files** (up arrow) icons.
 
-This includes the **Launcher** (blue plus sign; see above for more information), **New Folder** (folder symbol with plus sign), and **Upload Files** (up arrow) icons.
+Running Terminals and Kernels
+:   Running Terminals and Kernels monitors and manages active processes in your JupyterLab environment, such as running notebooks, terminals, and associated kernels.
 
-2. **Running Terminals and Kernels**
+Dask
+:   [Dask](https://docs.dask.org/en/stable/) is a Python library for parallel and distributed computing.
+    It is available by default in the main {term}`Python kernel <kernel>` `python3`, and can be used from a script or a notebook.
+    Additionally, the Fornax Science Console includes the [Dask JupyterLab Extension](https://github.com/dask/dask-labextension) (dask-labextension) which is a visual [dashboard](https://docs.dask.org/en/latest/dashboard.html) that can be used to manage clusters and profile parallel code.
 
-Monitors and manages active processes in your JupyterLab environment, such as running notebooks, terminals, and associated kernels.
+    A cluster can be started from either the dask-labextension or a notebook:
 
-3. **Dask**
+    -   **Using the dask-labextension**:
+        To start a cluster, click the dask-labextension icon (<img src="../_static/dask_logo.svg" height=15>) in the left sidebar and then click `+NEW`.
+        A dashboard with yellow buttons will show up that link to different profiling charts.
+        Information about the new cluster are displayed at the bottom of that pane, including code that helps you connect to that cluster from a notebook (drag the `<>` icon into a notebook cell to copy the code).
 
-[Dask](https://docs.dask.org/en/stable/) is a Python library for parallel and distributed computing.
-It is available by default in the main {term}`Python kernel <kernel>` `python3`, and can be used from a script or a notebook.
-Additionally, the Fornax Science Console includes the [Dask JupyterLab Extension](https://github.com/dask/dask-labextension) (dask-labextension) which is a visual [dashboard](https://docs.dask.org/en/latest/dashboard.html) that can be used to manage clusters and profile parallel code.
+    -   **In a notebook**, run a code like the following:
 
-A cluster can be started from either the dask-labextension or a notebook:
+        ```python
+        from dask.distributed import Client
+        client = Client(threads_per_worker=4, n_workers=2, memory_limit='4GB')
+        client
+        ```
 
--   **Using the dask-labextension**:
-    To start a cluster, click the dask-labextension icon (<img src="../_static/dask_logo.svg" height=15>) in the left sidebar and then click `+NEW`.
-    A dashboard with yellow buttons will show up that link to different profiling charts.
-    Information about the new cluster are displayed at the bottom of that pane, including code that helps you connect to that cluster from a notebook (drag the `<>` icon into a notebook cell to copy the code).
+        This will print information about the cluster, including the link to the dashboard of the form: `/jupyter/user/<USERNAME>/proxy/<PORT>/status`.
+        Clicking the link will open a new browser window to the dashboard.
+        You can also connect to the dashboard by copying and posting that link in the dask-labextension window.
+        Note: You may need to install `bokeh` in the same kernel as your notebook in order to display the profiling charts.
 
--   **In a notebook**, run a code like the following:
+    There are a few things to note when using Dask in the Fornax Science Console:
 
-    ```python
-    from dask.distributed import Client
-    client = Client(threads_per_worker=4, n_workers=2, memory_limit='4GB')
-    client
-    ```
-
-    This will print information about the cluster, including the link to the dashboard of the form: `/jupyter/user/<USERNAME>/proxy/<PORT>/status`.
-    Clicking the link will open a new browser window to the dashboard.
-    You can also connect to the dashboard by copying and posting that link in the dask-labextension window.
-    Note: You may need to install `bokeh` in the same kernel as your notebook in order to display the profiling charts.
-
-There are a few things to note when using Dask in the Fornax Science Console:
-
--   `dask[distributed]` is pre-installed in the default kernel `python3`.
-    If you plan to use it with a different kernel, you'll need to install it there with `pip install dask[distributed]`.
--   Currently, Fornax only supports clusters running in the same instance.
-    We plan to support launching instances in a Kubernetes cluster in the near future.
+    -   `dask[distributed]` is pre-installed in the default kernel `python3`.
+        If you plan to use it with a different kernel, you'll need to install it there with `pip install dask[distributed]`.
+    -   Currently, Fornax only supports clusters running in the same instance.
+        We plan to support launching instances in a Kubernetes cluster in the near future.
 
 (git-extension)=
-4. **Git**
+Git
+:   This extension integrates Git version control into the JupyterLab interface, enabling you to stage, commit, push, and pull notebook and code changes without leaving the environment.
+    It provides visual diffs, branch management, and history browsing, making collaborative development and reproducibility seamless.
+    See {ref}`using-git` for more information about setup and authentication and [jupyterlab-git](https://github.com/jupyterlab/jupyterlab-git) for more information about the extension.
 
-This extension integrates Git version control into the JupyterLab interface, enabling you to stage, commit, push, and pull notebook and code changes without leaving the environment.
-It provides visual diffs, branch management, and history browsing, making collaborative development and reproducibility seamless.
-See {ref}`using-git` for more information about setup and authentication and [jupyterlab-git](https://github.com/jupyterlab/jupyterlab-git) for more information about the extension.
+Table of Contents
+:   Automatically generates a sidebar outline of all headings in your notebook or document, allowing you to quickly navigate between sections.
 
-5. **Table of Contents**
-
-Automatically generates a sidebar outline of all headings in your notebook or document, allowing you to quickly navigate between sections.
-
-6. **Extensions Manager**
-
-Shows installed extensions and lets you manage them.
+Extensions Manager
+:   Shows installed extensions and lets you manage them.
 
 ## Right Toolbar
 
 The right toolbar is a vertical strip of icons, each representing a tool or panel that will open up in the right column of the interface.
 
-1. **Property Inspector**
+Property Inspector
+:   The Property Inspector shows metadata, configuration options, or properties for the currently selected item in the JupyterLab interface.
 
-Shows metadata, configuration options, or properties for the currently selected item in the JupyterLab interface.
+Kernel Usage
+:   In JupyterLab, the {term}`kernel <kernel>` is the computational engine that executes your code.
+    It is connected to an {term}`environment <environment>` with installed software.
+    When you open a {term}`notebook <Jupyter Notebook>` or {term}`console <Jupyter Console>` in JupyterLab, it connects to a kernel that runs the code you write, keeps track of variables, and returns output (such as plots, results, or errors) back to the interface.
 
-2. **Kernel Usage**
+    The Kernel Usage tool monitors resources (such as {term}`CPU` and {term}`memory <RAM>`) being used by your Jupyter kernel.
 
-In JupyterLab, the {term}`kernel <kernel>` is the computational engine that executes your code.
-It is connected to an {term}`environment <environment>` with installed software.
-When you open a {term}`notebook <Jupyter Notebook>` or {term}`console <Jupyter Console>` in JupyterLab, it connects to a kernel that runs the code you write, keeps track of variables, and returns output (such as plots, results, or errors) back to the interface.
-
-The Kernel Usage tool monitors resources (such as {term}`CPU` and {term}`memory <RAM>`) being used by your Jupyter kernel.
-
-3. **Debugger**
-
-Allows you to step through your code to identify bugs, understand the flow of execution, and troubleshoot issues in real-time by providing features like breakpoints, variable inspection, and call stacks.
+Debugger
+:   The Debugger allows you to step through your code to identify bugs, understand the flow of execution, and troubleshoot issues in real-time by providing features like breakpoints, variable inspection, and call stacks.
 
 (jupyterlab-session-information)=
 # JupyterLab Session Information

--- a/documentation/jupyterlab.md
+++ b/documentation/jupyterlab.md
@@ -96,10 +96,12 @@ There are a few things to note when using Dask in the Fornax Science Console:
 -   Currently, Fornax only supports clusters running in the same instance.
     We plan to support launching instances in a Kubernetes cluster in the near future.
 
+(git-extension)=
 4. **Git**
 
 This extension integrates Git version control into the JupyterLab interface, enabling you to stage, commit, push, and pull notebook and code changes without leaving the environment.
 It provides visual diffs, branch management, and history browsing, making collaborative development and reproducibility seamless.
+See {ref}`using-git` for more information about setup and authentication and [jupyterlab-git](https://github.com/jupyterlab/jupyterlab-git) for more information about the extension.
 
 5. **Table of Contents**
 

--- a/documentation/jupyterlab.md
+++ b/documentation/jupyterlab.md
@@ -15,8 +15,26 @@ JupyterLab deployed in the Fornax Science Console
 
 The main work area in JupyterLab is the central space where you open and interact with documents, {term}`notebooks <Jupyter Notebook>`, {term}`terminals <Terminal>`, {term}`consoles <Jupyter Console>`, and other panels.
 It supports multi-document, tabbed, and split-pane layouts, allowing you to work with multiple files side by side.
-
 You can drag and arrange tabs freely, view code, outputs, data files, or terminals in one unified interface, and seamlessly switch between tasks—making it a flexible environment for data analysis, coding, and exploration.
+
+### Launcher
+
+The **Launcher** panel provides clickable tiles for quickly starting new tools, such as notebooks and terminals.
+This panel may be open by default when a session starts and a new one can be opened at any time by clicking the plus sign to the right of open tabs.
+Many of the tools are standard for JupyterLab and more information about them can be found at the documentation linked above.
+Below we discuss some of the other tools available via the **Launcher**.
+
+**VS Code** will open a new window where you can work in a web-based integrated development environment (IDE).
+It is powered by [code-server](https://github.com/coder/code-server) which runs [Visual Studio Code - Open Source](https://github.com/microsoft/vscode) in a remote environment.
+See those links for more information.
+Note: Microsoft-specific customizations like GitHub Copilot are only available in Microsoft's desktop version of VS Code and so cannot be accessed here.
+
+**Terminal** provides a {term}`command line <terminal>`, which allows users to run Emacs, vi, Python, etc.
+
+The **Fornax** section contains links to the {ref}`forsc-dashboard`, documentation (this website), and the {ref}`intro-forum`.
+
+**Firefly** is a visualization platform designed to facilitate interactive exploration of astronomical data, including images, catalogs, and plots, through a modern, browser-based interface.
+See [jupyter_firefly_extensions](https://github.com/Caltech-IPAC/jupyter_firefly_extensions) for more information about this extension, including example notebooks that demonstrate the extension features.
 
 ## Menu Bar (Topmost horizontal menu)
 
@@ -39,19 +57,7 @@ Lets you navigate and open files and folders.
 Double-click a file or .ipynb notebook to open it in the main area.
 Opening .md files as notebooks should be done by right clicking on the file → "Open With" → "Notebook" so that they display in the expected format with cells of runnable code.
 
-This includes the **Launcher**(blue plus sign), **New Folder** (folder symbol with plus sign), and **Upload Files** (up arrow) icons.
-
-The **Launcher** will open a panel in the main area that provides clickable tiles for quickly starting new tools, such as notebooks and terminals.
-Below we discuss some of the tools available via the **Launcher**.
-
-**VS Code** will open a new window where you can work in a web-based integrated development environment (IDE).
-It is powered by [code-server](https://github.com/coder/code-server) which runs [Visual Studio Code - Open Source](https://github.com/microsoft/vscode) in a remote environment.
-See those links for more information.
-Note: Microsoft-specific customizations like GitHub Copilot are only available in Microsoft's desktop version of VS Code and so cannot be accessed here.
-
-**Firefly** is a visualization platform designed to facilitate interactive exploration of astronomical data, including images, catalogs, and plots, through a modern, browser-based interface.
-
-**Terminal** provides a {term}`command line <terminal>`, which allows users to run Emacs, vi, Python, etc.
+This includes the **Launcher** (blue plus sign; see above for more information), **New Folder** (folder symbol with plus sign), and **Upload Files** (up arrow) icons.
 
 2. **Running Terminals and Kernels**
 

--- a/documentation/jupyterlab.md
+++ b/documentation/jupyterlab.md
@@ -38,7 +38,7 @@ See [jupyter_firefly_extensions](https://github.com/Caltech-IPAC/jupyter_firefly
 
 ## Menu Bar (Topmost horizontal menu)
 
-This contains dropdown menus like File, Edit, etc., and the *Fornax* menu. which includes:
+This contains dropdown menus like File, Edit, etc., and the *Fornax* menu, which includes:
 
 - Useful links to the Fornax main dashboard, the documentation and community forum.
 - `Update Notebooks` can be used ensure the notebooks in the home directory are up to date. Note that the notebooks can also be updated by calling the `update-notebooks.sh` command from the terminal.
@@ -65,30 +65,36 @@ Monitors and manages active processes in your JupyterLab environment, such as ru
 
 3. **Dask**
 
-[dask](https://docs.dask.org/en/stable/) is a Python library for parallel and distributed computing.
-
+[Dask](https://docs.dask.org/en/stable/) is a Python library for parallel and distributed computing.
 It is available by default in the main {term}`Python kernel <kernel>` `python3`, and can be used from a script or a notebook.
+Additionally, the Fornax Science Console includes the [Dask JupyterLab Extension](https://github.com/dask/dask-labextension) (dask-labextension) which is a visual [dashboard](https://docs.dask.org/en/latest/dashboard.html) that can be used to manage clusters and profile parallel code.
 
-Additionally, the Fornax Science Console includes the Dask JupyterLab Extension which is a visual [dashboard](https://docs.dask.org/en/latest/dashboard.html) that can be used to manage clusters and profile parallel code.
+A cluster can be started from either the dask-labextension or a notebook:
 
-A cluster can be started either from a notebook or by using the dask lab-extension (colored <img src="../_static/dask_logo.svg" height=15> icon in the left sidebar):
+-   **Using the dask-labextension**:
+    To start a cluster, click the dask-labextension icon (<img src="../_static/dask_logo.svg" height=15>) in the left sidebar and then click `+NEW`.
+    A dashboard with yellow buttons will show up that link to different profiling charts.
+    Information about the new cluster are displayed at the bottom of that pane, including code that helps you connect to that cluster from a notebook (drag the `<>` icon into a notebook cell to copy the code).
 
-- Using the lab-extension:
+-   **In a notebook**, run a code like the following:
 
-To start a cluster, click the dask lab-extension and at the bottom, click `+NEW`. A dashboard with yellow buttons will show up that link to different profiling charts. Information about the new cluster are displayed at the bottom of that pane, including code that helps you connect to that cluster from a notebook (drag the `<>` icon into a notebook cell to copy the code).
+    ```python
+    from dask.distributed import Client
+    client = Client(threads_per_worker=4, n_workers=2, memory_limit='4GB')
+    client
+    ```
 
-- In a notebook, run a code like the following:
+    This will print information about the cluster, including the link to the dashboard of the form: `/jupyter/user/<USERNAME>/proxy/<PORT>/status`.
+    Clicking the link will open a new browser window to the dashboard.
+    You can also connect to the dashboard by copying and posting that link in the dask-labextension window.
+    Note: You may need to install `bokeh` in the same kernel as your notebook in order to display the profiling charts.
 
-```python
-from dask.distributed import Client
-client = Client(threads_per_worker=4, n_workers=2, memory_limit='4GB')
-client
-```
-This will print information about the cluster, including the link to the dashboard of the form: '/jupyter/user/<USERNAME>/proxy/<PORT>/status'. Clicking the link will open a new browser window to the dashboard. You can also connect to the dashboard by copying and posting that link in the dask lab-extension window.
+There are a few things to note when using Dask in the Fornax Science Console:
 
-There are a few things to note when using dask in the Fornax Science Console:
-- Currently, Fornax only supports clusters running in the same instance. We plan to support launching instances in a Kubernetes cluster in the near future.
-- `dask[distributed]` is pre-installed in the default kernel `python3`. If you plan to use it with a different kernel, you'll need to install it there with `pip install dask[distributed]`. Additionally, if you want to use the dashboard with clusters started in a notebook, you may also need to install `bokeh` in that kernel to display the profiling charts. `bokeh` is not needed for clusters started from the lab-extension dashboard.
+-   `dask[distributed]` is pre-installed in the default kernel `python3`.
+    If you plan to use it with a different kernel, you'll need to install it there with `pip install dask[distributed]`.
+-   Currently, Fornax only supports clusters running in the same instance.
+    We plan to support launching instances in a Kubernetes cluster in the near future.
 
 4. **Git**
 
@@ -96,6 +102,7 @@ This extension integrates Git version control into the JupyterLab interface, ena
 It provides visual diffs, branch management, and history browsing, making collaborative development and reproducibility seamless.
 
 5. **Table of Contents**
+
 Automatically generates a sidebar outline of all headings in your notebook or document, allowing you to quickly navigate between sections.
 
 6. **Extensions Manager**

--- a/documentation/jupyterlab.md
+++ b/documentation/jupyterlab.md
@@ -37,8 +37,9 @@ Fornax
 :   The Fornax section contains links to the {ref}`forsc-dashboard`, documentation (this website), and the {ref}`intro-forum`.
 
 Firefly
-:   Firefly is a visualization platform designed to facilitate interactive exploration of astronomical data, including images, catalogs, and plots, through a modern, browser-based interface.
-    See [jupyter_firefly_extensions](https://github.com/Caltech-IPAC/jupyter_firefly_extensions) for more information about this extension, including example notebooks that demonstrate the extension features.
+:   Firefly is a modern web-based GUI for accessing and exploring astronomical data with advanced data visualization capabilities.
+    This extension ([jupyter_firefly_extensions](https://github.com/Caltech-IPAC/jupyter_firefly_extensions)) allows users to visualize interlinked images, catalogs, charts, and more from their notebooks in a Firefly viewer embedded within JupyterLab.
+    Check out Firefly's Python API and full capabilities at [firefly-client documentation](https://caltech-ipac.github.io/firefly_client/) and the example notebooks demonstrating them at [IRSA tutorials](https://caltech-ipac.github.io/irsa-tutorials/).
 
 ## Menu Bar (Topmost horizontal menu)
 

--- a/documentation/markdown_and_code_dev.md
+++ b/documentation/markdown_and_code_dev.md
@@ -47,6 +47,8 @@ If you prefer to develop your code outside the Fornax Science Console, you can p
 
 ### Using Git
 
+You can use `git` from the command line or the UI provided by the {ref}`Git extension <git-extension>`.
+
 To set up `git` for the first time, configure your name and email by opening a {term}`terminal <terminal>` and running the following commands:
 
 ```sh

--- a/documentation/markdown_and_code_dev.md
+++ b/documentation/markdown_and_code_dev.md
@@ -9,37 +9,58 @@ These include {term}`Jupyter Notebook`s, Linux {term}`command-line <terminal>` a
 
 A Jupyter Notebook is a feature-rich application supporting data exploration and code development.
 The notebook documents may be in either `.ipynb` or `.md` (Markdown) format.
-The Fornax Tutorial Notebooks are in `.md` format following the standard practice of the Scientific Python ecosystem.
+The Fornax Tutorial Notebooks are in `.md` format ([MyST](https://mystmd.org/) Markdown flavor) following the standard practice of the Scientific Python ecosystem.
 While many astronomers are familiar with the `.ipynb` format, we chose Markdown for its superior readability, ease of version control through diffing, simpler testing workflows, and smooth rendering to HTML.
 To read more about the differences between `.md` and `.ipynb`, see the [MyST Markdown documentation](https://mystmd.org/guide/md-vs-ipynb).
 
 ### JupyterLab Markdown Dependencies
 
 On the Fornax Science Console, all required dependencies for using Markdown in JupyterLab are pre-installed.
+
 To use Markdown notebooks in JupyterLab outside of the Fornax Science Console, ensure the following tools are installed:
 
 -   [`jupytext`](https://github.com/mwouts/jupytext) Python library
 -   [`jupyterlab-myst`](https://github.com/executablebooks/jupyterlab-myst) JupyterLab extension
 
+(open-md-in-jupyterlab)=
 ### Opening `.md` Files in JupyterLab
 
-1.  Navigate to the `.md` file in the JupyterLab file browser.
-2.  Right-click the file, select **Open With**, and choose **Notebook** or **Jupytext Notebook**.
-3.  The Markdown file will open in an interactive notebook interface with cells and execution capabilities—just like a traditional `.ipynb` notebook.
+In the Fornax Science Console, you can simply double click on a `.md` file in the file browser.
+It will open in an interactive notebook interface with cells and execution capabilities — just like a traditional `.ipynb` notebook.
+If you need to save the notebook output, pair it with a `.ipynb` document before running it by selecting: `File → Jupytext → Pair Notebook with ipynb document`.
 
-### Converting `.md` Markdown Notebooks to `.py` Scripts
+If you are not in the Fornax Science Console then the default viewer for `.md` files might be different.
+In that case, right-click the file, select **Open With**, and choose **Notebook** or **Jupytext Notebook** to open it in the interactive notebook interface.
 
-It is easy to convert from `.md` Markdown to a `.py` script, if that fits better into your workflow:
+### Converting To and From `.md` Format
+
+:::{tip}
+It is not necessary to convert `.md` to `.ipynb` before using a notebook!
+Notebooks in `.md` format can be used in JupyterLab just like a traditional notebook.
+See {ref}`open-md-in-jupyterlab`.
+:::
+
+It is easy to convert notebooks between file formats like `.md`, `.ipynb`, and `.py` using [jupytext](https://jupytext.readthedocs.io/):
 
 1.  Open a terminal.
 2.  Install **jupytext** if necessary (it is pre-installed in the Fornax Science Console):
 
     ```pip install jupytext```
 
-3.  Navigate to the directory containing your `.md` notebook file.
-4.  Run the following command to convert it to a Python script:
+3.  Navigate to the directory containing your notebook file.
+4.  Run a `jupytext` command to convert the format.
+    Some examples are:
+    -   Convert `.ipynb` to a MyST Markdown `.md` notebook:
 
-    ```jupytext --to script <your_notebook_file>.md```
+        ```jupytext --from notebook --to myst <your_notebook_file>.ipynb```
+
+    -   Convert `.md` to a `.ipynb` notebook (*not necessary for use in JupyterLab*):
+
+        ```jupytext --from notebook --to myst <your_notebook_file>.ipynb```
+
+    -   Convert `.md` to a `.py` Python script:
+
+        ```jupytext --to script <your_notebook_file>.md```
 
 ## Moving Between Compute Platforms
 

--- a/documentation/markdown_and_code_dev.md
+++ b/documentation/markdown_and_code_dev.md
@@ -9,7 +9,7 @@ These include {term}`Jupyter Notebook`s, Linux {term}`command-line <terminal>` a
 
 A Jupyter Notebook is a feature-rich application supporting data exploration and code development.
 The notebook documents may be in either `.ipynb` or `.md` (Markdown) format.
-The Fornax Tutorial Notebooks are in `.md` format ([MyST](https://mystmd.org/) Markdown flavor) following the standard practice of the Scientific Python ecosystem.
+The Fornax Tutorial Notebooks are in `.md` format (specifically in [MyST](https://mystmd.org/) Markdown flavor) following the standard practice of the Scientific Python ecosystem.
 While many astronomers are familiar with the `.ipynb` format, we chose Markdown for its superior readability, ease of version control through diffing, simpler testing workflows, and smooth rendering to HTML.
 To read more about the differences between `.md` and `.ipynb`, see the [MyST Markdown documentation](https://mystmd.org/guide/md-vs-ipynb).
 
@@ -52,11 +52,11 @@ It is easy to convert notebooks between file formats like `.md`, `.ipynb`, and `
     Some examples are:
     -   Convert `.ipynb` to a MyST Markdown `.md` notebook:
 
-        ```jupytext --from notebook --to myst <your_notebook_file>.ipynb```
+        ```jupytext --to md:myst <your_notebook_file>.ipynb```
 
     -   Convert `.md` to a `.ipynb` notebook (*not necessary for use in JupyterLab*):
 
-        ```jupytext --from notebook --to myst <your_notebook_file>.ipynb```
+        ```jupytext --to ipynb <your_notebook_file>.md```
 
     -   Convert `.md` to a `.py` Python script:
 


### PR DESCRIPTION
Closes #122 

Cleanup JupyterLab page:
- Make Launcher a subsection of Main Work Area instead of describing all of that info underneath the File Browser bullet.
- Clean up formatting, especially in the Dask section (eg, one sentence per line). Also rearrange the Dask section a little bit.
- Add cross links between the Using Git section (on a different page) and the text on this page that explains the Git extension.

Expand Working with Markdown Notebooks section:
- Specify that we use MyST Markdown flavor.
- Add a `{tip}` clarifying that it's not necessary to convert .md -> .ipynb.
- Add a couple of jupytext conversion examples.

Other changes:
- Add an external link to the Dashboard.