### PR TITLE
Adding label to notebook section

### DIFF
--- a/documentation/notebook_tutorials.md
+++ b/documentation/notebook_tutorials.md
@@ -7,6 +7,7 @@ Once tested, these notebooks are rendered into HTML for easy reading: [Fornax Tu
 They can be downloaded in `.md` (Markdown) format and run in any JupyterLab environment with the same user experience as traditional `.ipynb` notebooks.
 See {ref}`working-with-markdown`.
 
+(notebooks-in-fornax)=
 ## Notebooks in the Console
 
 When you login to the console, the tutorial notebooks are available in your home directory at `~/fornax-notebooks`.


### PR DESCRIPTION
We need to get into the habit of adding more of these labels for easier cross linking between the docs and notebook html renderings.

I go ahead and merge this in straight away, so I can reuse it at the other side.