### PR TITLE
ANN: adding banner about open beta

### DIFF
--- a/myst.yml
+++ b/myst.yml
@@ -18,7 +18,7 @@ extends:
 site:
   template: book-theme
   parts:
-     banner: "📢 Announcement: Fornax is in Open Beta."
+     banner: "📢 Announcement: The Fornax Science Console welcomes Beta testers."
   options:
      favicon: _static/fornax_favicon.ico
      logo: _static/fornax_logo.png


### PR DESCRIPTION
Banner shows up at the top of all the pages until the user clicks on the closing x.

Screenshots are here, but also have a look at the rendering preview:

<img width="1346" height="408" alt="Screenshot 2025-12-17 at 16 26 47" src="https://github.com/user-attachments/assets/f7eee152-398a-4748-a7aa-82dd9629c3ec" />

<img width="1415" height="411" alt="Screenshot 2025-12-17 at 16 26 35" src="https://github.com/user-attachments/assets/320e2831-d004-4ecc-bce2-2dc723a83c87" />
