### PR TITLE
Clarify to choose an email that gets quick delivery

### DIFF
--- a/documentation/quick_start.md
+++ b/documentation/quick_start.md
@@ -15,7 +15,7 @@ The form will ask for the following:
 
 -   Name, email address, and phone number.
     We use these for verification purposes only.
-    Remember your email address as it will be used for ongoing Multi-Factor Authentication (MFA) and will be required in case you need to reset your password.
+    Your email address will be used for ongoing Multi-Factor Authentication (MFA), so please choose one that receives messages quickly and reliably.
 -   Institute affiliation and career stage, for demographics.
 -   A brief description of the science analysis you would like to use Fornax for.
     We use this to verify that the proposed usage of Fornax is appropriate.


### PR DESCRIPTION
Very short PR to address this request that came out of the Fornax management meeting this morning:

> In quick start guide, add something about choosing an email where you can get MFA emails. For instance, if you get your email forwarded, you might not get it in time.