### PR TITLE
Make CircleCI ignore `main`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,4 +48,8 @@ workflows:
   version: 2
   build-and-docs:
     jobs:
-      - build-docs
+      - build-docs:
+          filters:
+            branches:
+              ignore:
+                - main


### PR DESCRIPTION
CircleCI currently runs on push to `main`. I don't think it needs to, since GHA handles the deployment. Sometimes circleci fails because (eg) good links fail to resolve, and I have to spend time looking at our jobs before understanding that the deployment succeeded and the circleci job is simply irrelevant. This PR makes circleci ignore `main`, same as our notebooks repo.