### PR TITLE
Be explicit about phone and email for registration

### DIFF
--- a/documentation/quick_start.md
+++ b/documentation/quick_start.md
@@ -15,7 +15,8 @@ The form will ask for the following:
 
 -   Name, email address, and phone number.
     We use these for verification purposes only.
-    Your email address will be used for ongoing Multi-Factor Authentication (MFA), so please choose one that receives messages quickly and reliably.
+    You will need access to both your email and phone in order to complete the registration process.
+    Your email address will also be used for ongoing Multi-Factor Authentication (MFA), so please choose one that receives messages quickly and reliably.
 -   Institute affiliation and career stage, for demographics.
 -   A brief description of the science analysis you would like to use Fornax for.
     We use this to verify that the proposed usage of Fornax is appropriate.


### PR DESCRIPTION
Add a sentence that explicitly says users will need to access both their email and phone in order to complete the registration step. This has been a stumbling block for at least two people.