### PR TITLE
Add Google Analytics tracking ID to myst.yml

### DIFF
--- a/myst.yml
+++ b/myst.yml
@@ -22,3 +22,4 @@ site:
   options:
      favicon: _static/fornax_favicon.ico
      logo: _static/fornax_logo.png
+     analytics_google: G-VW2CL80W4S


### PR DESCRIPTION
@trjaffe set up a google analytics account and generated a tracking ID, should let us see how many people are using the documentation, which pages they're using most etc.

Tess added my UMBC google account to the analytics, which seems to have worked fine, so she should be able to do the same with anyone else who is interested.

