### PR TITLE
BUG: make builds fail for missing cross references

### DIFF
--- a/myst.yml
+++ b/myst.yml
@@ -12,6 +12,8 @@ project:
       keys:
         # some cross linking, ignore these until we can change the upstream source
         - https://docs.fornax.sciencecloud.nasa.gov/user-resource-allotments-and-costs
+    - rule: reference-target-resolves
+      severity: error
 extends:
   - toc.yml
 


### PR DESCRIPTION
This should make sure the CI is failing for issues like https://github.com/nasa-fornax/fornax-documentation/pull/210#discussion_r2771379048