### PR TITLE
Adding licence to the rendered pages

### DIFF
--- a/myst.yml
+++ b/myst.yml
@@ -6,6 +6,9 @@ project:
   # description: Fornax User documentation
   # keywords: []
   github: https://github.com/nasa-fornax/fornax-documentation
+  license:
+    id: BSD-3-Clause
+    url: https://github.com/nasa-fornax/fornax-documentation/blob/main/LICENSE
   error_rules:
     - rule: link-resolves
       severity: ignore


### PR DESCRIPTION
This is almost certainly incorrect as we don't have any code in this repo that can be BSD licenced, we need to update both the licence file and then this entry, too with a documentation appropriate licence.


cc @troyraen @zoghbi-a 