### PR TITLE
Document workaround to bug where PDFs won't open in Safari

### DIFF
--- a/documentation/faq.md
+++ b/documentation/faq.md
@@ -164,7 +164,6 @@ It is set to 15 minutes, but it can take a few minutes longer for the culling se
 
 This is a known issue in displaying HTML and PDF files inside JupyterLab in Safari.
 The workaround is to right-click (double finger tap) on the file and select 'Open in New Browser Tab'.
-The file should open correctly in a new browser tab.
 
 (using-git)=
 ## How do I use Git from Fornax?

--- a/documentation/faq.md
+++ b/documentation/faq.md
@@ -160,10 +160,10 @@ Starting a new session with a larger [server size](#server-and-env-options) will
 
 It is set to 15 minutes, but it can take a few minutes longer for the culling service to be triggered.
 
-## Why is my HTML page blank when opened inside JupyterLab with Safari?
+## Why is my HTML or PDF page blank when opened inside JupyterLab with Safari?
 
-This is a known issue in displaying HTML files inside JupyterLab in Safari.
-The workaround is to right-click (double finger tap) on the HTML file and select 'Open in New Browser Tab'.
+This is a known issue in displaying HTML and PDF files inside JupyterLab in Safari.
+The workaround is to right-click (double finger tap) on the file and select 'Open in New Browser Tab'.
 The file should open correctly in a new browser tab.
 
 (using-git)=


### PR DESCRIPTION
Closes https://discourse.fornax.sciencecloud.nasa.gov/t/safari-wont-open-a-pdf-open-in-a-new-browser-tab-option-does-nothing/984

PDFs won't open in JupyterLab when Safari is used. This is the same upstream bug as the HTML/Safari one we already have an FAQ for, so this PR adds PDF to that FAQ.