### PR TITLE
Moving short titles from individual pages to toc.yml

### DIFF
--- a/documentation/data_access.md
+++ b/documentation/data_access.md
@@ -1,7 +1,3 @@
----
-short_title: Data Access
----
-
 (data-access)=
 # Data Access from within Fornax
 

--- a/documentation/fornax_community_forum.md
+++ b/documentation/fornax_community_forum.md
@@ -1,7 +1,3 @@
----
-short_title: Forum and Helpdesk
----
-
 (intro-forum)=
 # Fornax Community Forum and Helpdesk
 

--- a/documentation/markdown_notebooks.md
+++ b/documentation/markdown_notebooks.md
@@ -1,7 +1,3 @@
----
-short_title: Markdown Notebooks
----
-
 (working-with-markdown)=
 # Working with Notebooks in Markdown Format
 

--- a/documentation/notebook_tutorials.md
+++ b/documentation/notebook_tutorials.md
@@ -1,7 +1,3 @@
-----
-short_title: Tutorial Notebooks
-----
-
 (fornax-tutorials)=
 # Fornax Python Tutorial Notebooks
 

--- a/toc.yml
+++ b/toc.yml
@@ -11,14 +11,18 @@ project:
         - file: documentation/server_options.md
         - file: documentation/compute_environments.md
         - file: documentation/data_storage.md
-    - file: documentation/notebook_tutorials.md
-    - file: documentation/data_access.md
+    - title: Tutorial Notebooks
+      file: documentation/notebook_tutorials.md
+    - title: Data Access
+      file: documentation/data_access.md
     - title: Developing Code
       children:
-        - file: documentation/markdown_notebooks.md
+        - title: Markdown Notebooks
+          file: documentation/markdown_notebooks.md
         - file: documentation/writing_cloud_optimized.md
     - file: documentation/faq.md
-    - file: documentation/fornax_community_forum.md
+    - title: Forum and Helpdesk
+      file: documentation/fornax_community_forum.md
     - file: documentation/acknowledgement.md
     - title: New User Documents
       children:


### PR DESCRIPTION
## Summary

This PR moves the short navigation titles for the four documentation pages listed below from page-level front matter into `toc.yml`, and addresses #197. 

documentation/data_access.md
documentation/fornax_community_forum.md
documentation/markdown_notebooks.md
documentation/notebook_tutorials.md